### PR TITLE
Refactor API

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Install the library directly from its source code repository. You will
 _not_ get the `examples` and `tests` with the quick install instructions.
 
 ```
-$ pip install git+https://github.com/robes/chisel.git
+$ pip install https://github.com/informatics-isi-edu/chisel.git
 ```
 
 For system-wide installations, use `sudo` and execute the command without the 
@@ -32,7 +32,7 @@ This installation method gets a copy of the source and then installs it.
 
 1. Clone the source repository
     ```sh
-    $ git clone git+https://github.com/robes/chisel.git
+    $ git clone https://github.com/informatics-isi-edu/chisel.git
     ```
 2. Install
     ```sh
@@ -43,7 +43,7 @@ This installation method gets a copy of the source and then installs it.
     for current user only install.
 3. Run the tests
     ```sh
-    $ export CHISEL_TEST_ERMREST_HOST=my-ermrest-host.example.org
+    $ export DERIVA_PY_TEST_HOSTNAME=my-ermrest-host.example.org
     $ python -m unittest discover
     ```
     See [the notes below on setting environment variables for testing](#testing). 
@@ -68,11 +68,11 @@ The package includes unit tests. They may be run without any configuration,
 however, certain test cases and suites will be skipped without the following
 environment variables defined.
 
-* `CHISEL_TEST_ERMREST_HOST`:
+* `DERIVA_PY_TEST_HOSTNAME`:
   To run the ERMrest catalog test suite, set this variable to the hostname of
   a server running an ERMrest service. You will also need to establish valid
   user credentials (e.g., by using the Deriva-Auth client).
-* `CHISEL_TEST_ERMREST_CATALOG`:
+* `DERIVA_PY_TEST_CATALOG`:
   In addition, set this variable to reuse a catalog. This variable is typically
   only used during development activities that would motivate frequently
   repeated test runs.

--- a/chisel/catalog/base.py
+++ b/chisel/catalog/base.py
@@ -814,7 +814,7 @@ class Table (object):
         return dot
 
     @valid_model_object
-    def copy(self, table_name, schema_name=None):
+    def copy(self, table_name, schema_name=None):  # TODO: remove this method or leave only as syntactic sugar for 'select(*)'
         """Makes a copy of this table.
 
         This operation must be performed in isolation of other evolve operations. It will setup the evolve block

--- a/chisel/catalog/base.py
+++ b/chisel/catalog/base.py
@@ -556,10 +556,10 @@ class Table (object):
             self, [(col['name'], self._new_column_instance(col)) for col in table_doc.get('column_definitions', [])]
         )
         # TODO: eventually these need chisel model objects
-        # self._keys = [_em.Key(self.sname, self.name, key_doc) for key_doc in table_doc.get('keys', [])]
+        # self._keys = [_em.Key(self.schema.name, self.name, key_doc) for key_doc in table_doc.get('keys', [])]
         self._keys = [key_doc for key_doc in table_doc.get('keys', [])]
         # TODO: eventually these need chisel model objects
-        # self._foreign_keys = [_em.ForeignKey(self.sname, self.name, fkey_doc) for fkey_doc in table_doc.get('foreign_keys', [])]
+        # self._foreign_keys = [_em.ForeignKey(self.schema.name, self.name, fkey_doc) for fkey_doc in table_doc.get('foreign_keys', [])]
         self._foreign_keys = [fkey_doc for fkey_doc in table_doc.get('foreign_keys', [])]
         self._referenced_by = []
         self._valid = True
@@ -704,7 +704,7 @@ class Table (object):
             ] + [
                 [col.name, type2str(col.type), str(col.nullok), col.default, col.comment] for col in self.columns.values()
             ]
-            desc = "### Table \"" + str(self.sname) + "." + str(self.name) + "\"\n" + \
+            desc = "### Table \"" + str(self.schema.name) + "." + str(self.name) + "\"\n" + \
                    util.markdown_table(data, quote)
             return desc
 
@@ -727,7 +727,7 @@ class Table (object):
         dot = Digraph(name=self.name, engine=engine, node_attr={'shape': 'box'})
 
         # add node
-        label = "%s.%s" % (self.sname, self.name)
+        label = "%s.%s" % (self.schema.name, self.name)
         dot.node(label, label)
 
         # track referenced nodes
@@ -735,7 +735,7 @@ class Table (object):
 
         # add edges
         # add outbound edges
-        tail_name = "%s.%s" % (self.sname, self.name)
+        tail_name = "%s.%s" % (self.schema.name, self.name)
         for fkey in self.foreign_keys:
             refcol = fkey.referenced_columns[0]
             head_name = "%s.%s" % (refcol['schema_name'], refcol['table_name'])

--- a/chisel/catalog/base.py
+++ b/chisel/catalog/base.py
@@ -812,19 +812,10 @@ class Table (object):
         return dot
 
     @valid_model_object
-    def copy(self, table_name, schema_name=None):  # TODO: remove this method or leave only as syntactic sugar for 'select(*)'
+    def copy(self):
         """Makes a copy of this table.
-
-        This operation must be performed in isolation of other evolve operations. It will setup the evolve block
-        internally.
-
-        :param table_name: the table copy will be given this name
-        :param schema_name: the table copy will be created in this schema; if None, then it will be copied to the same
-                            schema as this table.
         """
-        schema = self.schema.catalog.schemas[schema_name] if schema_name else self.schema
-        with schema.catalog.evolve():
-            schema.tables[table_name] = self.select()
+        return self.select()
 
     @valid_model_object
     def select(self, *columns):

--- a/chisel/catalog/base.py
+++ b/chisel/catalog/base.py
@@ -1113,23 +1113,21 @@ class Column (object):
     def _rename(self, new_name):
         """Renames the column.
 
-        This method cannot be called within another 'evolve' block. It must be performed in isolation.
-
         :param new_name: new name for the column
         """
-        with self.table.schema.catalog.evolve(allow_alter=True):  # TODO: don't do the evolve implicitly
-            projection = []
-            for cname in self.table.columns:
-                if cname == self.name:
-                    projection.append(self.alias(new_name))
-                else:
-                    projection.append(cname)
-            self.table.schema[self.table.name] = self.table.select(*projection)
+        # project out all columns with this column aliased
+        projection = []
+        for cname in self.table.columns:
+            if cname == self.name:
+                projection.append(self.alias(new_name))
+            else:
+                projection.append(cname)
+        self.table.schema[self.table.name] = self.table.select(*projection)
 
         # update local copy of name
         self._name = new_name
         # "refresh" the containing table
-        self.table._refresh()  # TODO: not sure if this will be needed/correct if evolve block above is removed
+        self.table._refresh()  # TODO: this should work as a temporary measure until the evolve block is committed or aborted
 
     @valid_model_object
     def to_atoms(self, delim=',', unnest_fn=None):

--- a/chisel/catalog/base.py
+++ b/chisel/catalog/base.py
@@ -719,7 +719,7 @@ class Table (object):
         :param column_name: the name of the column to be dropped.
         """
         column = self.columns[column_name]
-        with self.schema.catalog.evolve(allow_alter=True):
+        with self.schema.catalog.evolve(allow_alter=True):  # TODO: remove evolve block
             self.schema[self._name] = self.select(column.inv())
 
     def __getitem__(self, item):
@@ -1123,7 +1123,7 @@ class Column (object):
 
         :param new_name: new name for the column
         """
-        with self.table.schema.catalog.evolve(allow_alter=True):
+        with self.table.schema.catalog.evolve(allow_alter=True):  # TODO: don't do the evolve implicitly
             projection = []
             for cname in self.table.columns:
                 if cname == self.name:
@@ -1135,7 +1135,7 @@ class Column (object):
         # update local copy of name
         self._name = new_name
         # "refresh" the containing table
-        self.table._refresh()
+        self.table._refresh()  # TODO: not sure if this will be needed/correct if evolve block above is removed
 
     @valid_model_object
     def to_atoms(self, delim=',', unnest_fn=None):

--- a/chisel/catalog/base.py
+++ b/chisel/catalog/base.py
@@ -790,8 +790,8 @@ class Table (object):
         return dot
 
     @valid_model_object
-    def copy(self):
-        """Makes a copy of this table.
+    def clone(self):
+        """Clone this table.
         """
         return self.select()
 

--- a/chisel/catalog/base.py
+++ b/chisel/catalog/base.py
@@ -851,12 +851,18 @@ class Table (object):
     @valid_model_object
     def link(self, target):
         """Creates a reference from this table to the target table."""
-        raise NotImplementedError('This catalog does not support this method.')
+        # TODO: may need to introduce new Link operator
+        #       projection of table +column(s) needed as the foriegn key, inference of key columns from target table
+        #       add'l physical operation to add the fkey reference
+        raise NotImplementedError('This method is not yet supported.')
 
     @valid_model_object
     def associate(self, target):
         """Creates a many-to-many "association" between this table and "target" table."""
-        raise NotImplementedError('This catalog does not support this method.')
+        # TODO: may need to introduce new Associate operator
+        #       project of new table w/ column(s) for each foriegn key to inferred keys of target tables
+        #       add'l physical operation to add the fkey reference(s)
+        raise NotImplementedError('This method is not yet supported.')
 
 
 class ColumnCollection (collections.OrderedDict):

--- a/chisel/catalog/base.py
+++ b/chisel/catalog/base.py
@@ -821,13 +821,13 @@ class Table (object):
                 if isinstance(column, Column):
                     projection.append(column.name)
                 elif isinstance(column, str) or isinstance(column, _op.AttributeAlias)\
-                        or isinstance(column, _op.AttributeRemoval) or isinstance(column, _op.AttributeAdd):
+                        or isinstance(column, _op.AttributeDrop) or isinstance(column, _op.AttributeAdd):
                     projection.append(column)
                 else:
                     raise ValueError("Unsupported projection type '{}'".format(type(column).__name__))
 
-            # validation: if any mutation (add/remove), all must be mutations (can't mix with other projections)
-            for mutation in (_op.AttributeAdd, _op.AttributeRemoval):
+            # validation: if any mutation (add/drop), all must be mutations (can't mix with other projections)
+            for mutation in (_op.AttributeAdd, _op.AttributeDrop):
                 mutations = [isinstance(o, mutation) for o in projection]
                 if any(mutations):
                     if not all(mutations):
@@ -1103,9 +1103,9 @@ class Column (object):
     def inv(self):
         """Removes an attribute when used in a projection.
 
-        :return: a sybolic expression for the removed column
+        :return: a symbolic expression for the removed column
         """
-        return _op.AttributeRemoval(self.name)
+        return _op.AttributeDrop(self.name)
 
     __invert__ = inv
 

--- a/chisel/catalog/base.py
+++ b/chisel/catalog/base.py
@@ -708,16 +708,6 @@ class Table (object):
         """
         return Column(column_doc, self)
 
-    @valid_model_object
-    def _drop_column(self, column_name):
-        """Drops a column of this relation.
-
-        :param column_name: the name of the column to be dropped.
-        """
-        column = self.columns[column_name]
-        with self.schema.catalog.evolve(allow_alter=True):  # TODO: remove evolve block
-            self.schema[self._name] = self.select(column.inv())
-
     def __getitem__(self, item):
         """Maps a column name to a column model object.
 
@@ -919,8 +909,8 @@ class ColumnCollection (collections.OrderedDict):
     def __delitem__(self, key):
         # get handle to the column
         column = self[key]
-        # drop column from catalog model
-        self._table._drop_column(key)
+        # assign a projection of parent table without this column
+        self._table.schema[self._table.name] = self._table.select(column.inv())
         # invalidate model object
         column.valid = False
         # delete from column collection

--- a/chisel/catalog/base.py
+++ b/chisel/catalog/base.py
@@ -160,7 +160,7 @@ class AbstractCatalog (object):
                     logging.debug("Committing current catalog model mutation operations.")
                     self.parent._commit(self.dry_run, self.consolidate)
             finally:
-                # resent the schemas
+                # reset the schemas
                 for schema in self.parent.schemas.values():
                     schema.tables.reset()
                 # remove the evolve context
@@ -504,6 +504,16 @@ class TableCollection (collections.abc.MutableMapping):
     def __setitem__(self, key, value):
         # for directly creating a table...
         if not self._schema.catalog._evolve_ctx:
+
+            # TODO: when no evolve ctx set, do immediate/implicit commit
+            #  if value is Mapping (ie, Table definition):
+            #    process as follows...
+            #  elif value is ComputedRelation:
+            #    with self.catalog.evolve():
+            #      self._tables[key] = self._pending[key] = ComputedRelation(_op.Assign(...)...)
+            #      ...evolved here at exit of implicit evolve block
+            #    return self._tables[key]  ...to return the newly materialized relation
+
             if not isinstance(value, collections.abc.Mapping):
                 raise CatalogMutationError("No catalog mutation context set.")
             if 'table_name' not in value:

--- a/chisel/catalog/deriva.py
+++ b/chisel/catalog/deriva.py
@@ -73,13 +73,13 @@ class DerivaCatalog (ERMrestCatalog):
         #     aliased columns from the original columns. Also, columns may be aliased more than once.
         #  2) 'special' case for deletes only: as a syntactic sugar, many formulations of project support the
         #     notation of "-foo,-bar,..." meaning that the operator will project all _except_ those '-name' columns.
-        #     We support that by first including the special symbol 'AllAttributes' followed by 'AttributeRemoval'
+        #     We support that by first including the special symbol 'AllAttributes' followed by 'AttributeDrop'
         #     symbols.
 
         if projection[0] == optimizer.AllAttributes():  # 'special' case for deletes only
             logger.debug("Dropping columns that were explicitly removed.")
             for removal in projection[1:]:
-                assert isinstance(removal, optimizer.AttributeRemoval)
+                assert isinstance(removal, optimizer.AttributeDrop)
                 logger.debug("Deleting column '{cname}'.".format(cname=removal.name))
                 original_columns[removal.name].delete()
 

--- a/chisel/catalog/ermrest.py
+++ b/chisel/catalog/ermrest.py
@@ -201,20 +201,6 @@ class ERMrestCatalog (base.AbstractCatalog):
         table = schema.tables[table_name]
         table.drop()
 
-    def _do_link_tables(self, schema_name, table_name, target_schema_name, target_table_name):
-        """Link tables in the catalog."""
-        # TODO: may need to introduce new Link operator
-        #       projection of table +column(s) needed as the foriegn key, inference of key columns from target table
-        #       add'l physical operation to add the fkey reference
-        raise NotImplementedError('Not supported by %s.' % type(self).__name__)
-
-    def _do_associate_tables(self, schema_name, table_name, target_schema_name, target_table_name):
-        """Associate tables in the catalog."""
-        # TODO: may need to introduce new Associate operator
-        #       project of new table w/ column(s) for each foriegn key to inferred keys of target tables
-        #       add'l physical operation to add the fkey reference(s)
-        raise NotImplementedError('Not supported by %s.' % type(self).__name__)
-
     def _determine_model_changes(self, computed_relation):
         """Determines the model changes to be produced by this computed relation."""
         return dict(mappings=[], constraints=[], policies=[])
@@ -264,17 +250,3 @@ class ERMrestTable (base.Table):
     def logical_plan(self):
         """The logical plan used to compute this relation; intended for internal use."""
         return optimizer.ERMrestExtant(self.schema.catalog, self.schema.name, self.name)
-
-    @base.valid_model_object
-    def link(self, target):
-        """Creates a reference from this table to the target table."""
-        with self.schema.catalog.evolve():  # TODO: get rid of this evolve block
-            # TODO: eventually the _do_... statements should just be moved here
-            self.schema.catalog._do_link_tables(self.schema.name, self.name, target.schema.name, target.name)
-
-    @base.valid_model_object
-    def associate(self, target):
-        """Creates a many-to-many "association" between this table and "target" table."""
-        with self.schema.catalog.evolve():  # TODO: get rid of this evolve block
-            # TODO: eventually the _do_... statements should just be moved here
-            self.schema.catalog._do_associate_tables(self.schema.name, self.name, target.schema.name, target.name)

--- a/chisel/catalog/ermrest.py
+++ b/chisel/catalog/ermrest.py
@@ -150,7 +150,8 @@ class ERMrestCatalog (base.AbstractCatalog):
         dst_schema = self.schemas[dst_schema_name]
         with self.evolve():  # TODO: should refactor this so that it doesn't have to be performed in a evolve block
             dst_schema.tables[dst_table_name] = src_table.select()
-        del src_schema.tables[src_table_name]
+        with self.evolve(allow_drop=True):  # TODO: remove undo block here
+          del src_schema.tables[src_table_name]
 
     # TODO: should not need this if handled via projection and rules to infer an 'alter' mode
     def _do_alter_table_add_column(self, schema_name, table_name, column_doc):

--- a/chisel/catalog/ermrest.py
+++ b/chisel/catalog/ermrest.py
@@ -152,6 +152,7 @@ class ERMrestCatalog (base.AbstractCatalog):
             dst_schema.tables[dst_table_name] = src_table.select()
         del src_schema.tables[src_table_name]
 
+    # TODO: should not need this if handled via projection and rules to infer an 'alter' mode
     def _do_alter_table_add_column(self, schema_name, table_name, column_doc):
         """Alter table Add column in the catalog"""
         model = self.ermrest_catalog.getCatalogModel()
@@ -234,10 +235,16 @@ class ERMrestCatalog (base.AbstractCatalog):
 
     def _do_link_tables(self, schema_name, table_name, target_schema_name, target_table_name):
         """Link tables in the catalog."""
+        # TODO: may need to introduce new Link operator
+        #       projection of table +column(s) needed as the foriegn key, inference of key columns from target table
+        #       add'l physical operation to add the fkey reference
         raise NotImplementedError('Not supported by %s.' % type(self).__name__)
 
     def _do_associate_tables(self, schema_name, table_name, target_schema_name, target_table_name):
         """Associate tables in the catalog."""
+        # TODO: may need to introduce new Associate operator
+        #       project of new table w/ column(s) for each foriegn key to inferred keys of target tables
+        #       add'l physical operation to add the fkey reference(s)
         raise NotImplementedError('Not supported by %s.' % type(self).__name__)
 
     def _determine_model_changes(self, computed_relation):
@@ -285,6 +292,7 @@ class ERMrestSchema (base.Schema):
 class ERMrestTable (base.Table):
     """Extant table in an ERMrest catalog."""
 
+    # TODO: will not need this when abstract table is updated
     @base.valid_model_object
     def _add_column(self, column_doc):
         """ERMrest specific implementation of add column function."""
@@ -313,6 +321,7 @@ class ERMrestTable (base.Table):
             del self.schema.tables._backup[self.name]  # TODO: this is kludgy should revise
             self.schema.tables.reset()
 
+    # TODO: remove the 'copy' operation
     @base.valid_model_object
     def copy(self, table_name, schema_name=None):
         """ERMrest catalog specific implementation of 'copy' method."""
@@ -322,11 +331,13 @@ class ERMrestTable (base.Table):
     @base.valid_model_object
     def link(self, target):
         """Creates a reference from this table to the target table."""
-        with self.schema.catalog.evolve():
+        with self.schema.catalog.evolve():  # TODO: get rid of this evolve block
+            # TODO: eventually the _do_... statements should just be moved here
             self.schema.catalog._do_link_tables(self.schema.name, self.name, target.schema.name, target.name)
 
     @base.valid_model_object
     def associate(self, target):
         """Creates a many-to-many "association" between this table and "target" table."""
-        with self.schema.catalog.evolve():
+        with self.schema.catalog.evolve():  # TODO: get rid of this evolve block
+            # TODO: eventually the _do_... statements should just be moved here
             self.schema.catalog._do_associate_tables(self.schema.name, self.name, target.schema.name, target.name)

--- a/chisel/catalog/ermrest.py
+++ b/chisel/catalog/ermrest.py
@@ -157,7 +157,7 @@ class ERMrestCatalog (base.AbstractCatalog):
         # Notes: currently, there are two distinct scenarios in a projection,
         #  1) 'general' case: the projection is an improper subset of the relation's columns, and may include some
         #     aliased columns from the original columns. Also, columns may be aliased more than once.
-        #  2) 'special' case for add/drop only: 'AllAttributes' followed by 'AttributeRemoval'
+        #  2) 'special' case for add/drop only: 'AllAttributes' followed by 'AttributeDrop'
         #     or 'AttributeAdd' symbols.
 
         # TODO:
@@ -174,7 +174,7 @@ class ERMrestCatalog (base.AbstractCatalog):
         if projection[0] == optimizer.AllAttributes():  # 'special' case for drops or adds only
             logger.debug("Dropping columns that were explicitly removed.")
             for item in projection[1:]:
-                if isinstance(item, optimizer.AttributeRemoval):
+                if isinstance(item, optimizer.AttributeDrop):
                     logger.debug("Dropping column '{cname}'.".format(cname=item.name))
                     original_columns[item.name].drop()
                 elif isinstance(item, optimizer.AttributeAdd):

--- a/chisel/catalog/ermrest.py
+++ b/chisel/catalog/ermrest.py
@@ -136,13 +136,6 @@ class ERMrestCatalog (base.AbstractCatalog):
         schema = self.ermrest_catalog.getCatalogModel().schemas[schema_name]
         schema.create_table(table_doc)
 
-    def _do_copy_table(self, src_schema_name, src_table_name, dst_schema_name, dst_table_name):
-        """Copy table in the catalog."""
-        src_schema = self.schemas[src_schema_name]
-        dst_schema = self.schemas[dst_schema_name]
-        src_table = src_schema.tables[src_table_name]
-        dst_schema.tables[dst_table_name] = src_table.select()  # requires that this be performed w/in evolve block
-
     def _do_move_table(self, src_schema_name, src_table_name, dst_schema_name, dst_table_name):
         """Rename table in the catalog."""
         src_schema = self.schemas[src_schema_name]
@@ -321,13 +314,6 @@ class ERMrestTable (base.Table):
         if self.name in self.schema.tables._backup:
             del self.schema.tables._backup[self.name]  # TODO: this is kludgy should revise
             self.schema.tables.reset()
-
-    # TODO: remove the 'copy' operation
-    @base.valid_model_object
-    def copy(self, table_name, schema_name=None):
-        """ERMrest catalog specific implementation of 'copy' method."""
-        with self.schema.catalog.evolve():
-            self.schema.catalog._do_copy_table(self.schema.name, self.name, schema_name or self.schema.name, table_name)
 
     @base.valid_model_object
     def link(self, target):

--- a/chisel/catalog/ermrest.py
+++ b/chisel/catalog/ermrest.py
@@ -57,13 +57,14 @@ class ERMrestCatalog (base.AbstractCatalog):
             if not self._evolve_ctx.allow_alter:
                 raise base.CatalogMutationError('"allow_alter" flag is not True')
 
+            # TODO: need to get -- orig_sname, orig_tname = plan.child.description['...'], plan.child.description['...']
             altered_schema_name, altered_table_name = plan.description['schema_name'], plan.description['table_name']
-            self._do_alter_table(altered_schema_name, altered_table_name, plan.projection)
+            self._do_alter_table(altered_schema_name, altered_table_name, plan.projection)  # TODO: orig_sname/tname, ...
 
             # Note: repair the model following the alter table
             #  invalidate the altered table model object
             schema = self.schemas[altered_schema_name]
-            invalidated_table = self[altered_schema_name].tables._backup[altered_table_name]  # get the original table
+            invalidated_table = self[altered_schema_name].tables._backup[altered_table_name]  # TODO: get the original table
             invalidated_table.valid = False
             #  introspect the schema on the revised table
             model_doc = self.ermrest_catalog.getCatalogSchema()
@@ -157,11 +158,11 @@ class ERMrestCatalog (base.AbstractCatalog):
         ermrest_table = model.schemas[schema_name].tables[table_name]
         ermrest_table.create_column(column_doc)
 
-    def _do_alter_table(self, schema_name, table_name, projection):
+    def _do_alter_table(self, schema_name, table_name, projection):  # TODO: sname, tname, new_sname, new_tname, projection
         """Alter table (general) in the catalog."""
         model = self.ermrest_catalog.getCatalogModel()
-        schema = model.schemas[schema_name]
-        table = schema.tables[table_name]
+        schema = model.schemas[schema_name]  # TODO: sname
+        table = schema.tables[table_name]    # TODO: tname
         original_columns = {c.name: c for c in table.column_definitions}
 
         # Notes: currently, there are two distinct scenarios in a projection,
@@ -172,6 +173,17 @@ class ERMrestCatalog (base.AbstractCatalog):
         #     We support that by first including the special symbol 'AllAttributes' followed by 'AttributeRemoval'
         #     symbols.
 
+        # TODO:
+        #  3) change schema name
+        #  4) change table name
+
+        # if sname != new_sname:  # rename schema name
+        #     # ...
+        #
+        # elif tname != new_tname:  # rename table name
+        #     # ...
+
+        # elif ...  TODO: will probably be mutually exclusive with column renames
         if projection[0] == optimizer.AllAttributes():  # 'special' case for deletes only
             logger.debug("Dropping columns that were explicitly removed.")
             for removal in projection[1:]:

--- a/chisel/catalog/semistructured.py
+++ b/chisel/catalog/semistructured.py
@@ -119,7 +119,7 @@ class SemistructuredTable (base.Table):
     @property
     def logical_plan(self):
         """The logical plan used to compute this relation; intended for internal use."""
-        filename = os.path.join(self.schema.catalog.path, self.sname, self.name)
+        filename = os.path.join(self.schema.catalog.path, self.schema.name, self.name)
         if filename.endswith('.csv') or filename.endswith('.tsv') or filename.endswith('.txt'):
             return optimizer.TabularDataExtant(filename=filename)
         elif filename.endswith('.json'):

--- a/chisel/operators/base.py
+++ b/chisel/operators/base.py
@@ -128,11 +128,16 @@ class Assign (PhysicalOperator):
     def __iter__(self):
         return iter(self._child)
 
+    @property
+    def child(self):
+        return self._child
+
 
 class Alter (Assign):
     """Alter operator takes the 'projection' which will define the mutation on the relation."""
-    def __init__(self, child, schema_name, table_name, projection):
-        super(Alter, self).__init__(child, schema_name, table_name)
+    def __init__(self, child, src_sname, src_tname, dst_sname, dst_tname, projection):
+        super(Alter, self).__init__(child, dst_sname, dst_tname)
+        self.src_sname, self.src_tname, self.dst_sname, self.dst_tname = src_sname, src_tname, dst_sname, dst_tname
         self.projection = projection
 
 
@@ -174,7 +179,7 @@ class Project (PhysicalOperator):
     """Basic projection operator."""
     def __init__(self, child, projection):
         super(Project, self).__init__()
-        assert projection, "No projection"
+        projection = projection or [_op.AllAttributes()]
         assert hasattr(projection, '__iter__'), "Projection is not an iterable collection"
         assert isinstance(child, PhysicalOperator)
         self._child = child
@@ -298,7 +303,6 @@ class Rename (Project):
     def __init__(self, child, renames):
         assert isinstance(child, PhysicalOperator)
         assert child.description
-        assert renames
         assert isinstance(renames, tuple)
         assert all([isinstance(rename, _op.AttributeAlias) for rename in renames])
 

--- a/chisel/operators/base.py
+++ b/chisel/operators/base.py
@@ -133,6 +133,12 @@ class Assign (PhysicalOperator):
         return self._child
 
 
+class Create (Assign):
+    """Create operator."""
+    def __init__(self, child, schema_name, table_name):
+        super(Create, self).__init__(child, schema_name, table_name)
+
+
 class Alter (Assign):
     """Alter operator takes the 'projection' which will define the mutation on the relation."""
     def __init__(self, child, src_sname, src_tname, dst_sname, dst_tname, projection):

--- a/chisel/operators/base.py
+++ b/chisel/operators/base.py
@@ -211,8 +211,8 @@ class Project (PhysicalOperator):
                 logger.debug("projecting an aliased attribute: %s", item)
                 self._alias_to_cname[item.alias] = item.name
                 self._cname_to_alias[item.name].append(item.alias)
-            elif isinstance(item, _op.AttributeRemoval):
-                logger.debug("projection with attribute removal: %s", item)
+            elif isinstance(item, _op.AttributeDrop):
+                logger.debug("projection with attribute drop: %s", item)
                 removals.add(item.name)
             elif isinstance(item, _op.AttributeAdd):
                 logger.debug("projection with attribute add: %s", item)

--- a/chisel/optimizer/__init__.py
+++ b/chisel/optimizer/__init__.py
@@ -4,6 +4,7 @@ from pyfpm import matcher as _fpm
 from . import rules as _rules
 from .symbols import *
 from .consolidate import consolidate
+from ..operators import PhysicalOperator
 
 
 def _execute_rules_single_pass(rules, op):
@@ -14,22 +15,20 @@ def _execute_rules_single_pass(rules, op):
     :return: rewritten operator
     """
     # test for terminal condition
-    if isinstance(op, Nil):
+    if isinstance(op, Nil) or isinstance(op, PhysicalOperator):
         return op
 
     # rewrite this operator
     try:
         op = rules(op)
     except _fpm.NoMatch:
-        pass
-
-    # recursively rewrite the children
-    for child in ['child', 'left', 'right']:
-        if hasattr(op, child):
-            try:
-                op = op._replace(**{child: _execute_rules_single_pass(rules, getattr(op, child))})
-            except _fpm.NoMatch:
-                pass
+        # recursively rewrite the children
+        for child in ['child', 'left', 'right']:
+            if hasattr(op, child):
+                try:
+                    op = op._replace(**{child: _execute_rules_single_pass(rules, getattr(op, child))})
+                except _fpm.NoMatch:
+                    pass
 
     # return the rewritten plan
     return op

--- a/chisel/optimizer/__init__.py
+++ b/chisel/optimizer/__init__.py
@@ -4,7 +4,6 @@ from pyfpm import matcher as _fpm
 from . import rules as _rules
 from .symbols import *
 from .consolidate import consolidate
-from ..operators import PhysicalOperator
 
 
 def _execute_rules_single_pass(rules, op):
@@ -14,8 +13,8 @@ def _execute_rules_single_pass(rules, op):
     :param op: input operator
     :return: rewritten operator
     """
-    # test for terminal condition
-    if isinstance(op, Nil) or isinstance(op, PhysicalOperator):
+    # terminate if op is Nil or is not a symbolic operator (tuple)
+    if isinstance(op, Nil) or not isinstance(op, tuple):
         return op
 
     # rewrite this operator

--- a/chisel/optimizer/rules.py
+++ b/chisel/optimizer/rules.py
@@ -147,7 +147,7 @@ logical_composition_rules = Matcher([
                     Project(domain, ('name', 'synonyms')),
                     Similar(attribute, 'name', 'synonyms', similarity_fn, grouping_fn),
                 ),
-                (AllAttributes(), AttributeRemoval(attribute), AttributeRemoval('synonyms'))
+                (AllAttributes(), AttributeDrop(attribute), AttributeDrop('synonyms'))
             ),
             (AttributeAlias(name='name', alias=attribute),)
         )

--- a/chisel/optimizer/rules.py
+++ b/chisel/optimizer/rules.py
@@ -1,5 +1,6 @@
 """Logical optimization, composition, and transformation rules."""
 
+import json
 from pyfpm.matcher import Matcher
 from .. import util
 from .. import operators as _op
@@ -162,8 +163,12 @@ logical_composition_rules = Matcher([
 #: rules for transforming logical plans to physical plans
 physical_transformation_rules = Matcher([
     (
-        'Assign(child:PhysicalOperator, schema, table_name)',
-        lambda child, schema, table_name: _op.Assign(child, schema, table_name)
+        'Assign(child:PhysicalOperator, schema, table)',
+        lambda child, schema, table: _op.Assign(child, schema, table)
+    ),
+    (
+        'Assign(child:str, schema, table)',
+        lambda child, schema, table: _op.Create(_op.Metadata(json.loads(child)), schema, table)
     ),
     (
         'Assign(Project(ERMrestExtant(catalog, src_sname, src_tname), attributes), dst_sname, dst_tname)'
@@ -177,8 +182,8 @@ physical_transformation_rules = Matcher([
         _op.Alter(_op.ERMrestProjectSelect(catalog, src_sname, src_tname, attributes), src_sname, src_tname, dst_sname, dst_tname, attributes)
     ),
     (
-        'Assign(Nil(), schema, table_name)',
-        lambda schema, table_name: _op.Drop(_op.Metadata({'schema_name': schema, 'table_name': table_name }), schema, table_name)
+        'Assign(Nil(), schema, table)',
+        lambda schema, table: _op.Drop(_op.Metadata({'schema_name': schema, 'table_name': table}), schema, table)
     ),
     (
         'TempVar(child)',

--- a/chisel/optimizer/rules.py
+++ b/chisel/optimizer/rules.py
@@ -169,14 +169,13 @@ physical_transformation_rules = Matcher([
         'Assign(Project(ERMrestExtant(catalog, src_sname, src_tname), attributes), dst_sname, dst_tname)'
         '   if (src_sname, src_tname) == (dst_sname, dst_tname)',
         lambda catalog, src_sname, src_tname, dst_sname, dst_tname, attributes:
-        _op.Alter(_op.ERMrestProjectSelect(catalog, src_sname, src_tname, attributes), dst_sname, dst_tname, attributes)
+        _op.Alter(_op.ERMrestProjectSelect(catalog, src_sname, src_tname, attributes), src_sname, src_tname, dst_sname, dst_tname, attributes)
     ),
-    # # TODO: possibly replace the above with this rule to cover schema/table renames in addition to attribute renames
-    # (
-    #     'Assign(Rename(ERMrestExtant(catalog, src_sname, src_tname), attributes), dst_sname, dst_tname)',
-    #     lambda catalog, src_sname, src_tname, dst_sname, dst_tname, attributes:
-    #     _op.Alter(_op.ERMrestProjectSelect(catalog, src_sname, src_tname, attributes), dst_sname, dst_tname, attributes)
-    # ),
+    (
+        'Assign(Rename(ERMrestExtant(catalog, src_sname, src_tname), attributes), dst_sname, dst_tname)',
+        lambda catalog, src_sname, src_tname, dst_sname, dst_tname, attributes:
+        _op.Alter(_op.ERMrestProjectSelect(catalog, src_sname, src_tname, attributes), src_sname, src_tname, dst_sname, dst_tname, attributes)
+    ),
     (
         'Assign(Nil(), schema, table_name)',
         lambda schema, table_name: _op.Drop(_op.Metadata({'schema_name': schema, 'table_name': table_name }), schema, table_name)

--- a/chisel/optimizer/rules.py
+++ b/chisel/optimizer/rules.py
@@ -66,7 +66,7 @@ logical_optimization_rules = Matcher([
         lambda: Nil()
     ),
     (
-        'Rename(child, dict())',
+        'Rename(child, dict())',  # TODO: remove this rule so it doesn't conflict with sname/tname only renames
         lambda child: child
     ),
     (
@@ -171,6 +171,12 @@ physical_transformation_rules = Matcher([
         lambda catalog, src_sname, src_tname, dst_sname, dst_tname, attributes:
         _op.Alter(_op.ERMrestProjectSelect(catalog, src_sname, src_tname, attributes), dst_sname, dst_tname, attributes)
     ),
+    # # TODO: possibly replace the above with this rule to cover schema/table renames in addition to attribute renames
+    # (
+    #     'Assign(Rename(ERMrestExtant(catalog, src_sname, src_tname), attributes), dst_sname, dst_tname)',
+    #     lambda catalog, src_sname, src_tname, dst_sname, dst_tname, attributes:
+    #     _op.Alter(_op.ERMrestProjectSelect(catalog, src_sname, src_tname, attributes), dst_sname, dst_tname, attributes)
+    # ),
     (
         'Assign(Nil(), schema, table_name)',
         lambda schema, table_name: _op.Drop(_op.Metadata({'schema_name': schema, 'table_name': table_name }), schema, table_name)

--- a/chisel/optimizer/symbols.py
+++ b/chisel/optimizer/symbols.py
@@ -121,8 +121,8 @@ AllAttributes = namedtuple('AllAttributes', '')
 #: attribute alias parameter
 AttributeAlias = namedtuple('AttributeAlias', 'name alias')
 
-#: attribute removal parameter, for removing a single attribute from a projection
-AttributeRemoval = namedtuple('AttributeRemoval', 'name')
+#: attribute drop parameter, for dropping a single attribute from a projection
+AttributeDrop = namedtuple('AttributeDrop', 'name')
 
 #: attribute add parameter, for adding a new attribute in a projection
 AttributeAdd = namedtuple('AttributeAdd', 'definition')

--- a/chisel/optimizer/symbols.py
+++ b/chisel/optimizer/symbols.py
@@ -124,6 +124,9 @@ AttributeAlias = namedtuple('AttributeAlias', 'name alias')
 #: attribute removal parameter, for removing a single attribute from a projection
 AttributeRemoval = namedtuple('AttributeRemoval', 'name')
 
+#: attribute add parameter, for adding a new attribute in a projection
+AttributeAdd = namedtuple('AttributeAdd', 'definition')
+
 #: function parameter
 IntrospectionFunction = namedtuple('IntrospectionFunction', 'fn')
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -46,7 +46,7 @@ with catalog.evolve(allow_drop=True):
 ```python
 import chisel
 catalog = chisel.connect(...)
-with catalog.evolve():  # TODO
+with catalog.evolve():
   table = catalog['public'].tables['foo']
   table.name = 'bar'
 ```
@@ -66,9 +66,9 @@ with catalog.evolve():
 ```python
 import chisel
 catalog = chisel.connect(...)
-with catalog.evolve():  # TODO
+with catalog.evolve():
   table = catalog.schemas['public'].tables['foo']
-  table.schema = catalog.schemas['bar']  # where 'bar' is a different schema in the catalog
+  table.schema = catalog.schemas['bar']
 ```
 
 ### Alter table add a column

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -37,7 +37,7 @@ list(foo.select().fetch())
 ```python
 import chisel
 catalog = chisel.connect(...)
-with catalog.evolve(allow_drop=True):  # TODO
+with catalog.evolve(allow_drop=True):
   del catalog['public'].tables['foo']
 ```
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -56,9 +56,9 @@ with catalog.evolve():  # TODO
 ```python
 import chisel
 catalog = chisel.connect(...)
-with catalog.evolve():  # TODO
+with catalog.evolve():
   table = catalog['public'].tables['foo']
-  catalog['public'].tables['bar'] = table.select() # or table.copy()
+  catalog['public'].tables['bar'] = table.copy()
 ```
 
 ### Move a table to a different schema

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -76,7 +76,7 @@ with catalog.evolve():  # TODO
 ```python
 import chisel
 catalog = chisel.connect(...)
-with catalog.evolve():  # TODO
+with catalog.evolve():
   table = catalog['public'].tables['foo']
   table.columns['baz'] = chisel.Column.define('baz', chisel.data_types.text, ...)
 ```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -17,7 +17,7 @@ import chisel
 from chisel import Table, Column, Key, ForeignKey
 catalog = chisel.connect(...)
 
-with catalog.evolve(): # TODO
+with catalog.evolve():
     # define table and assign to a schema in order to create it in the catalog
     catalog['public'].tables['foo'] = Table.define(
         'foo',

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -37,7 +37,8 @@ list(foo.select().fetch())
 ```python
 import chisel
 catalog = chisel.connect(...)
-del catalog['public'].tables['foo']
+with catalog.evolve(allow_drop=True):  # TODO
+  del catalog['public'].tables['foo']
 ```
 
 ### Rename a table
@@ -45,8 +46,9 @@ del catalog['public'].tables['foo']
 ```python
 import chisel
 catalog = chisel.connect(...)
-table = catalog['public'].tables['foo']
-table.name = 'bar'
+with catalog.evolve():  # TODO
+  table = catalog['public'].tables['foo']
+  table.name = 'bar'
 ```
 
 ### Copy a table
@@ -63,8 +65,9 @@ table.copy('new talbe name', schema_name='optional new schema name')
 ```python
 import chisel
 catalog = chisel.connect(...)
-table = catalog['public'].tables['foo']
-table.sname = 'bar'  # where 'bar' is a different schema in the catalog
+with catalog.evolve():  # TODO
+  table = catalog.schemas['public'].tables['foo']
+  table.schema = catalog.schemas['bar']  # where 'bar' is a different schema in the catalog
 ```
 
 ### Alter table add a column

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -56,8 +56,9 @@ with catalog.evolve():  # TODO
 ```python
 import chisel
 catalog = chisel.connect(...)
-table = catalog['public'].tables['foo']
-table.copy('new talbe name', schema_name='optional new schema name')
+with catalog.evolve():  # TODO
+  table = catalog['public'].tables['foo']
+  catalog['public'].tables['bar'] = table.select()
 ```
 
 ### Move a table to a different schema
@@ -75,8 +76,9 @@ with catalog.evolve():  # TODO
 ```python
 import chisel
 catalog = chisel.connect(...)
-table = catalog['public'].tables['foo']
-table.columns['baz'] = chisel.Column.define('baz', chisel.data_types.text)
+with catalog.evolve():  # TODO
+  table = catalog['public'].tables['foo']
+  table.columns['baz'] = chisel.Column.define('baz', chisel.data_types.text, ...)
 ```
 
 ### Alter table drop a column
@@ -84,8 +86,9 @@ table.columns['baz'] = chisel.Column.define('baz', chisel.data_types.text)
 ```python
 import chisel
 catalog = chisel.connect(...)
-table = catalog['public'].tables['foo']
-del table.columns['baz']
+with catalog.evolve():  # TODO
+  table = catalog['public'].tables['foo']
+  del table.columns['baz']
 ```
 
 ### Alter table rename a column
@@ -93,9 +96,10 @@ del table.columns['baz']
 ```python
 import chisel
 catalog = chisel.connect(...)
-table = catalog['public'].tables['foo']
-column = table.columns['baz']
-column.name = 'qux'
+with catalog.evolve():  # TODO
+  table = catalog['public'].tables['foo']
+  column = table.columns['baz']
+  column.name = 'qux'
 ```
 
 ### Link tables
@@ -106,9 +110,10 @@ the destination table (`bar`).
 ```python
 import chisel
 catalog = chisel.connect(...)
-foo = catalog['public'].tables['foo']
-bar = catalog['public'].tables['bar']
-foo.link(bar)
+with catalog.evolve():  # TODO
+  foo = catalog['public'].tables['foo']
+  bar = catalog['public'].tables['bar']
+  foo.link(bar)
 ```
 
 ### Associate tables
@@ -119,9 +124,10 @@ references between two tables (`foo` and `bar`).
 ```python
 import chisel
 catalog = chisel.connect(...)
-foo = catalog['public'].tables['foo']
-bar = catalog['public'].tables['bar']
-foo.associate(bar)
+with catalog.evolve():  # TODO
+  foo = catalog['public'].tables['foo']
+  bar = catalog['public'].tables['bar']
+  foo.associate(bar)
 ```
 
 ## Complex operations

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -17,15 +17,16 @@ import chisel
 from chisel import Table, Column, Key, ForeignKey
 catalog = chisel.connect(...)
 
-# define table and assign to a schema in order to create it in the catalog
-catalog['public'].tables['foo'] = Table.define(
-    'foo',
-    column_defs=[Column.define(...), ...],
-    key_defs=[Key.define(...), ...],
-    fkey_defs=[ForeignKey.define(...), ...],
-    ...)
+with catalog.evolve(): # TODO
+    # define table and assign to a schema in order to create it in the catalog
+    catalog['public'].tables['foo'] = Table.define(
+        'foo',
+        column_defs=[Column.define(...), ...],
+        key_defs=[Key.define(...), ...],
+        fkey_defs=[ForeignKey.define(...), ...],
+        ...)
 
-# get the newly created table in order to use it in operations    
+# get the newly created table in order to use it in operations
 foo = catalog['public'].tables['foo']
 
 # perform operations on new table 'foo'...
@@ -38,7 +39,7 @@ list(foo.select().fetch())
 import chisel
 catalog = chisel.connect(...)
 with catalog.evolve(allow_drop=True):
-  del catalog['public'].tables['foo']
+    del catalog['public'].tables['foo']
 ```
 
 ### Rename a table
@@ -47,8 +48,8 @@ with catalog.evolve(allow_drop=True):
 import chisel
 catalog = chisel.connect(...)
 with catalog.evolve():
-  table = catalog['public'].tables['foo']
-  table.name = 'bar'
+    table = catalog['public'].tables['foo']
+    table.name = 'bar'
 ```
 
 ### Clone a table
@@ -57,8 +58,8 @@ with catalog.evolve():
 import chisel
 catalog = chisel.connect(...)
 with catalog.evolve():
-  table = catalog['public'].tables['foo']
-  catalog['public'].tables['bar'] = table.clone()
+    table = catalog['public'].tables['foo']
+    catalog['public'].tables['bar'] = table.clone()
 ```
 
 ### Move a table to a different schema
@@ -67,8 +68,8 @@ with catalog.evolve():
 import chisel
 catalog = chisel.connect(...)
 with catalog.evolve():
-  table = catalog.schemas['public'].tables['foo']
-  table.schema = catalog.schemas['bar']
+    table = catalog.schemas['public'].tables['foo']
+    table.schema = catalog.schemas['bar']
 ```
 
 ### Alter table add a column
@@ -77,8 +78,8 @@ with catalog.evolve():
 import chisel
 catalog = chisel.connect(...)
 with catalog.evolve():
-  table = catalog['public'].tables['foo']
-  table.columns['baz'] = chisel.Column.define('baz', chisel.data_types.text, ...)
+    table = catalog['public'].tables['foo']
+    table.columns['baz'] = chisel.Column.define('baz', chisel.data_types.text, ...)
 ```
 
 ### Alter table drop a column
@@ -87,8 +88,8 @@ with catalog.evolve():
 import chisel
 catalog = chisel.connect(...)
 with catalog.evolve(allow_alter=True):
-  table = catalog['public'].tables['foo']
-  del table.columns['baz']
+    table = catalog['public'].tables['foo']
+    del table.columns['baz']
 ```
 
 ### Alter table rename a column
@@ -97,12 +98,14 @@ with catalog.evolve(allow_alter=True):
 import chisel
 catalog = chisel.connect(...)
 with catalog.evolve(allow_alter=True):
-  table = catalog['public'].tables['foo']
-  column = table.columns['baz']
-  column.name = 'qux'
+    table = catalog['public'].tables['foo']
+    column = table.columns['baz']
+    column.name = 'qux'
 ```
 
 ### Link tables
+
+\*\***Not Implemented Yet**\*\*
 
 This operation adds a foreign key reference from the source table (`foo`) to 
 the destination table (`bar`).
@@ -111,12 +114,14 @@ the destination table (`bar`).
 import chisel
 catalog = chisel.connect(...)
 with catalog.evolve():  # TODO
-  foo = catalog['public'].tables['foo']
-  bar = catalog['public'].tables['bar']
-  foo.link(bar)
+    foo = catalog['public'].tables['foo']
+    bar = catalog['public'].tables['bar']
+    foo.link(bar)
 ```
 
 ### Associate tables
+
+\*\***Not Implemented Yet**\*\*
 
 This operation adds an association table (`foo_bar`) with foreign key 
 references between two tables (`foo` and `bar`).
@@ -125,9 +130,9 @@ references between two tables (`foo` and `bar`).
 import chisel
 catalog = chisel.connect(...)
 with catalog.evolve():  # TODO
-  foo = catalog['public'].tables['foo']
-  bar = catalog['public'].tables['bar']
-  foo.associate(bar)
+    foo = catalog['public'].tables['foo']
+    bar = catalog['public'].tables['bar']
+    foo.associate(bar)
 ```
 
 ## Complex operations
@@ -172,8 +177,8 @@ Table `bar` will have a `name` column from the deduplicated values of `foo.bar`.
 import chisel
 catalog = chisel.connect(...)
 with catalog.evolve():
-  foo = catalog['public'].tables['foo']
-  catalog['public'].tables['bar'] = foo.columns['bar'].to_domain()
+    foo = catalog['public'].tables['foo']
+    catalog['public'].tables['bar'] = foo.columns['bar'].to_domain()
 ```
 
 ### Create table as vocabulary from existing column
@@ -186,8 +191,8 @@ that were not selected as canonical.
 import chisel
 catalog = chisel.connect(...)
 with catalog.evolve():
-  foo = catalog['public'].tables['foo']
-  catalog['public'].tables['bar'] = foo.columns['bar'].to_vocabulary()
+    foo = catalog['public'].tables['foo']
+    catalog['public'].tables['bar'] = foo.columns['bar'].to_vocabulary()
 ```
 
 ### Create table from atomizied values from existing column 
@@ -199,8 +204,8 @@ Table `bar` will have a column `bar` containing the unnested values of
 import chisel
 catalog = chisel.connect(...)
 with catalog.evolve():
-  foo = catalog['public'].tables['foo']
-  catalog['public'].tables['bar'] = foo.columns['bar'].to_atoms()
+    foo = catalog['public'].tables['foo']
+    catalog['public'].tables['bar'] = foo.columns['bar'].to_atoms()
 ```
 
 ### Create a table by reifying a concept embedded in another table
@@ -212,9 +217,11 @@ and the second set of columns used as the non-key columns of the new table.
 import chisel
 catalog = chisel.connect(...)
 with catalog.evolve():
-  foo = catalog['public'].tables['foo']
-  catalog['public'].tables['barbaz'] = foo.reify(
-    {foo.columns['id']}, {foo.columns['bar'], foo.columns['baz']})
+    foo = catalog['public'].tables['foo']
+    catalog['public'].tables['barbaz'] = foo.reify(
+        {foo.columns['id']}, 
+        {foo.columns['bar'], foo.columns['baz']}
+    )
 ```
 
 ### Create a table by reifying a sub-concept embedded in another table
@@ -227,8 +234,8 @@ introspected key of `foo`.
 import chisel
 catalog = chisel.connect(...)
 with catalog.evolve():
-  foo = catalog['public'].tables['foo']
-  catalog['public'].tables['bar'] = foo.reify_sub(foo.columns['bar'])
+    foo = catalog['public'].tables['foo']
+    catalog['public'].tables['bar'] = foo.reify_sub(foo.columns['bar'])
 ```
 
 ### Create a table by aligning a column with a vocabulary or domain table
@@ -244,9 +251,9 @@ the vocabulary or domain table (`vocab.bar` in the example here).
 import chisel
 catalog = chisel.connect(...)
 with catalog.evolve():
-  foo = catalog['public'].tables['foo']
-  bar_terms = catalog['vocab'].tables['bar']
-  catalog['public'].tables['foo_fixed'] = foo.columns['bar'].align(bar_terms)
+    foo = catalog['public'].tables['foo']
+    bar_terms = catalog['vocab'].tables['bar']
+    catalog['public'].tables['foo_fixed'] = foo.columns['bar'].align(bar_terms)
 ```
 
 ### Create a table by unnesting and aligning a column with a vocabulary or domain
@@ -262,7 +269,7 @@ foreign key to `foo` from where it came.
 import chisel
 catalog = chisel.connect(...)
 with catalog.evolve():
-  foo = catalog['public'].tables['foo']
-  bar_terms = catalog['vocab'].tables['bar']
-  catalog['public'].tables['foo_bar'] = foo.columns['bars'].to_tags(bar_terms)
+    foo = catalog['public'].tables['foo']
+    bar_terms = catalog['vocab'].tables['bar']
+    catalog['public'].tables['foo_bar'] = foo.columns['bars'].to_tags(bar_terms)
 ```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -86,7 +86,7 @@ with catalog.evolve():
 ```python
 import chisel
 catalog = chisel.connect(...)
-with catalog.evolve():  # TODO
+with catalog.evolve(allow_alter=True):
   table = catalog['public'].tables['foo']
   del table.columns['baz']
 ```
@@ -96,7 +96,7 @@ with catalog.evolve():  # TODO
 ```python
 import chisel
 catalog = chisel.connect(...)
-with catalog.evolve():  # TODO
+with catalog.evolve(allow_alter=True):
   table = catalog['public'].tables['foo']
   column = table.columns['baz']
   column.name = 'qux'

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -2,13 +2,31 @@
 
 This guide covers usage examples.
 
+## Catalog `evolve` block
+
+Operations must be performed within a `with catalog.evolve(): ...` block.
+The actual schema evolution is executed after the block exits successfully. If
+an exception is raised (and not caught), the evolution is aborted and the
+catalog model is restored to its original state.
+
+### Testing with `dry_run` flag
+
+In order to do a "dry run," call the evolve method with `dry_run=True` and at 
+the exit of the evolve block the plan and sample data of computed relations
+will be dumped to standard output. No changes to the catalog will be executed
+and the catalog model will be restored to its original state.
+
+### Guarding with `allow_alter` and `allow_drop`
+
+In order to guard against accidental table alteration or destruction, the 
+`evolve` method accepts `allow_alter` and `allow_drop` Boolean parameters. 
+By default, these parameters are `False` and the evolve block will prevent
+table alter or drop operations, respectively.
+
 ## Simple operations
 
-The simpler operators are generally equivalent to operations available in SQL 
+The simple operators are generally equivalent to operations available in SQL 
 DDL (data definition language).
-
-These operations need to be performed in _isolation_ and therefore cannot be 
-used within the `with catalog.evolve(): ...` blocks.
 
 ### Create a table
 
@@ -139,35 +157,6 @@ with catalog.evolve():  # TODO
 
 The complex operations cover chisel features that go beyond SQL DDL types of 
 operations.
-
-### Catalog `evolve` block
-
-These operations must be performed within a `with catalog.evolve(): ...` block.
-The actual schema evolution is executed after the block exits successfully. If
-an exception is raised (and not caught), the evolution is aborted and the
-catalog model is restored to its original state.
-
-### Testing with `dry_run` flag
-
-In order to do a "dry run," call the evolve method with `dry_run=True` and at 
-the exit of the evolve block the plan and sample data of computed relations
-will be dumped to standard output. No changes to the catalog will be executed
-and the catalog model will be restored to its original state.
-
-### Guarding with `allow_alter` and `allow_drop`
-
-In order to guard against accidental table alteration or destruction, the 
-`evolve` method accepts `allow_alter` and `allow_drop` Boolean parameters. 
-By default, these parameters are `False` and the evolve block will prevent
-table alter or drop operations, respectively.
-
-### Simple versus complex operations
-
-A key difference between the simple and complex operations is that the simple
-operations are performed in isolation. They cannot be called within an evolve
-context block. Internally, the basic (DDL like) operations will setup an 
-evolve block and set the appropriate flags to allow alter and drop operations
-to succeed.
 
 ### Create table as domain from existing column
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -58,7 +58,7 @@ import chisel
 catalog = chisel.connect(...)
 with catalog.evolve():  # TODO
   table = catalog['public'].tables['foo']
-  catalog['public'].tables['bar'] = table.select()
+  catalog['public'].tables['bar'] = table.select() # or table.copy()
 ```
 
 ### Move a table to a different schema

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -51,14 +51,14 @@ with catalog.evolve():  # TODO
   table.name = 'bar'
 ```
 
-### Copy a table
+### Clone a table
 
 ```python
 import chisel
 catalog = chisel.connect(...)
 with catalog.evolve():
   table = catalog['public'].tables['foo']
-  catalog['public'].tables['bar'] = table.copy()
+  catalog['public'].tables['bar'] = table.clone()
 ```
 
 ### Move a table to a different schema

--- a/test/catalog/test_base.py
+++ b/test/catalog/test_base.py
@@ -74,3 +74,15 @@ class TestBaseCatalog (BaseTestCase):
                 self._catalog.schemas['.'].tables['domain1'] = temp
         # table should be restored
         self.assertIsInstance(self._catalog['.'][self.catalog_helper.samples], Table, "Failed to restore tables")
+
+    def test_schema_describe(self):
+        self._catalog['.'].describe()
+
+    def test_table_describe(self):
+        self._catalog['.'][self.catalog_helper.samples].describe()
+
+    def test_schema_graph(self):
+        self._catalog['.'].graph()
+
+    def test_table_graph(self):
+        self._catalog['.'][self.catalog_helper.samples].graph()

--- a/test/catalog/test_ermrest.py
+++ b/test/catalog/test_ermrest.py
@@ -7,11 +7,11 @@ from test.utils import ERMrestHelper, BaseTestCase
 import chisel.optimizer as _op
 from chisel import data_types, Column, Table, ForeignKey
 
-ermrest_hostname = os.getenv('CHISEL_TEST_ERMREST_HOST')
-ermrest_catalog_id = os.getenv('CHISEL_TEST_ERMREST_CATALOG')
+ermrest_hostname = os.getenv('DERIVA_PY_TEST_HOSTNAME')
+ermrest_catalog_id = os.getenv('DERIVA_PY_TEST_CATALOG')
 
 
-@unittest.skipUnless(ermrest_hostname, 'ERMrest hostname not defined. Set "CHISEL_TEST_ERMREST_HOST" to enable test.')
+@unittest.skipUnless(ermrest_hostname, 'ERMrest hostname not defined.')
 class TestERMrestCatalog (BaseTestCase):
     """Unit test suite for ermrest catalog functionality."""
 

--- a/test/catalog/test_ermrest.py
+++ b/test/catalog/test_ermrest.py
@@ -300,7 +300,8 @@ class TestERMrestCatalog (BaseTestCase):
         original_table = self._catalog['public'].tables[self.catalog_helper.samples]
 
         # delete the table
-        del self._catalog['public'].tables[self.catalog_helper.samples]
+        with self._catalog.evolve(allow_drop=True):
+            del self._catalog['public'].tables[self.catalog_helper.samples]
 
         # validate that it is no longer in catalog
         ermrest_schema = self._catalog.ermrest_catalog.getCatalogSchema()
@@ -368,7 +369,7 @@ class TestERMrestCatalog (BaseTestCase):
 
         # validate that tables has been replaced in the catalog
         ermrest_schema = self._catalog.ermrest_catalog.getCatalogSchema()
-        self.assertNotIn(self.catalog_helper.samples, ermrest_schema['schemas']['public']['tables'],
+        self.assertNotIn(self.catalog_helper.samples, ermrest_schema['schemas']['public']['tables'].keys(),
                          'Table "%s" found in ermrest catalog schema' % self.catalog_helper.samples)
         self.assertIn(new_table_name, ermrest_schema['schemas']['public']['tables'],
                       'Table "%s" not found in ermrest catalog schema' % new_table_name)

--- a/test/catalog/test_ermrest.py
+++ b/test/catalog/test_ermrest.py
@@ -248,8 +248,9 @@ class TestERMrestCatalog (BaseTestCase):
         ).sort(dbptable.column_definitions['RID']).fetch()
 
         # do the rename
-        column = self._catalog['public'][self.catalog_helper.samples][projected_col_name]
-        column.name = projected_col_alias
+        with self._catalog.evolve(allow_alter=True):
+            column = self._catalog['public'][self.catalog_helper.samples][projected_col_name]
+            column.name = projected_col_alias
 
         # validate the local state object
         table_columns = self._catalog['public'][self.catalog_helper.samples].columns

--- a/test/catalog/test_ermrest.py
+++ b/test/catalog/test_ermrest.py
@@ -178,7 +178,8 @@ class TestERMrestCatalog (BaseTestCase):
     def test_alter_drop_column_via_del(self):
         removed_col_name = self.catalog_helper.FIELDS[1]
         removed_col = self._catalog['public'][self.catalog_helper.samples].columns[removed_col_name]
-        del self._catalog['public'][self.catalog_helper.samples].columns[removed_col_name]
+        with self._catalog.evolve(allow_alter=True):
+            del self._catalog['public'][self.catalog_helper.samples].columns[removed_col_name]
 
         # validate the schema names
         ermrest_schema = self._catalog.ermrest_catalog.getCatalogSchema()

--- a/test/catalog/test_ermrest.py
+++ b/test/catalog/test_ermrest.py
@@ -424,9 +424,11 @@ class TestERMrestCatalog (BaseTestCase):
         ermrest_schema = self._catalog.ermrest_catalog.getCatalogSchema()
         self.assertIn(cname, ermrest_schema['schemas']['public']['tables'])
 
+    @unittest.skip
     def test_link_tables(self):
         pass
 
+    @unittest.skip
     def test_associate_tables(self):
         pass
 

--- a/test/catalog/test_ermrest.py
+++ b/test/catalog/test_ermrest.py
@@ -58,7 +58,8 @@ class TestERMrestCatalog (BaseTestCase):
         table_def = Table.define(new_tname)
 
         # create the table
-        self._catalog['public'].tables[new_tname] = table_def
+        with self._catalog.evolve():
+            self._catalog['public'].tables[new_tname] = table_def
         self._is_table_valid(new_tname)
 
     def test_create_table_w_fkey(self):
@@ -87,7 +88,8 @@ class TestERMrestCatalog (BaseTestCase):
         )
 
         # create the table
-        self._catalog['public'].tables[new_tname] = table_def
+        with self._catalog.evolve():
+            self._catalog['public'].tables[new_tname] = table_def
         self._is_table_valid(new_tname)
 
     def test_allow_alter_err(self):

--- a/test/catalog/test_ermrest.py
+++ b/test/catalog/test_ermrest.py
@@ -317,7 +317,7 @@ class TestERMrestCatalog (BaseTestCase):
         self.assertNotIn(self.catalog_helper.samples, self._catalog['public'].tables,
                          'Table "%s" found in local catalog model' % self.catalog_helper.samples)
 
-    def test_copy_table_as_select(self):
+    def test_clone_table_as_select(self):
         # keep handle to table model object
         original_table = self._catalog['public'].tables[self.catalog_helper.samples]
         new_table_name = self._samples_copy_tname
@@ -340,14 +340,14 @@ class TestERMrestCatalog (BaseTestCase):
         self.assertIn(new_table_name, self._catalog['public'].tables,
                       'Table "%s" not found in local catalog model' % new_table_name)
 
-    def test_copy_table(self):
+    def test_clone_table(self):
         # keep handle to table model object
         original_table = self._catalog['public'].tables[self.catalog_helper.samples]
         new_table_name = self._samples_copy_tname
 
         # copy the table
         with self._catalog.evolve():
-            self._catalog['public'][new_table_name] = original_table.copy()
+            self._catalog['public'][new_table_name] = original_table.clone()
 
         # validate that original and copy are in the catalog
         ermrest_schema = self._catalog.ermrest_catalog.getCatalogSchema()

--- a/test/catalog/test_ermrest.py
+++ b/test/catalog/test_ermrest.py
@@ -343,7 +343,8 @@ class TestERMrestCatalog (BaseTestCase):
         new_table_name = self._samples_copy_tname
 
         # copy the table
-        original_table.copy(new_table_name, schema_name='public')
+        with self._catalog.evolve():
+            self._catalog['public'][new_table_name] = original_table.copy()
 
         # validate that original and copy are in the catalog
         ermrest_schema = self._catalog.ermrest_catalog.getCatalogSchema()

--- a/test/catalog/test_ermrest.py
+++ b/test/catalog/test_ermrest.py
@@ -283,7 +283,8 @@ class TestERMrestCatalog (BaseTestCase):
         # define new column
         new_col_name = 'NEW COLUMN NAME'
         col_def = Column.define(new_col_name, data_types['int8'])
-        self._catalog['public'][self.catalog_helper.samples].columns[new_col_name] = col_def
+        with self._catalog.evolve(allow_alter=True):
+          self._catalog['public'][self.catalog_helper.samples].columns[new_col_name] = col_def
 
         # validate the schema names
         ermrest_schema = self._catalog.ermrest_catalog.getCatalogSchema()


### PR DESCRIPTION
This branch refactors the APIs to use the revised Deriva Py API v. 1.0 (altercol and other changes). It also deprecates the deriva catalog manage API usage and makes updates to all APIs so that they execute in an evolve block.